### PR TITLE
Set a task's error environment before setting status to errored.

### DIFF
--- a/task.lisp
+++ b/task.lisp
@@ -46,8 +46,8 @@ Author: Nicolas Hafner <shinmera@tymoon.eu>
   (when (task-ready-p task)
     (restart-case
         (handler-bind ((error (lambda (err)
-                                (setf (status task) :errored)
-                                (setf (error-environment task) (dissect:capture-environment err)))))
+                                (setf (error-environment task) (dissect:capture-environment err))
+                                (setf (status task) :errored))))
           (setf (status task) :running)
           (multiple-value-prog1
               (call-next-method)


### PR DESCRIPTION
If waiting on a task to fail and then immediately inspecting the error environment, it's not always there.
Swapping set order avoids that race condition.